### PR TITLE
Add CSV and Parquet exports of the datasets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.csv filter=lfs diff=lfs merge=lfs -text
+*.parquet filter=lfs diff=lfs merge=lfs -text

--- a/data/export_data.m
+++ b/data/export_data.m
@@ -1,0 +1,27 @@
+clear
+
+load('hmc5883l_compass.mat')
+load('mpu6050_accelerometer.mat')
+load('mpu6050_gyroscope.mat')
+load('mpu6050_temperature.mat')
+
+csvwrite('hmc5883l_compass.csv', compassBuffer)
+csvwrite('mpu6050_accelerometer.csv', accelBuffer)
+csvwrite('mpu6050_gyroscope.csv', gyroBuffer)
+csvwrite('mpu6050_temperature.csv', temperatureBuffer)
+
+startTime = datetime(1970, 1, 1, 0, 0, 0);
+
+% Export MPU6050 data as Parquet
+mpu6050TimeIndex = startTime + seconds(accelBuffer(:, 1));
+mpu6050Combined = [accelBuffer(:, 1), accelBuffer(:, 2:end), gyroBuffer(:, 2:end), temperatureBuffer(:, 2:end)];
+T = array2table(mpu6050Combined, 'VariableNames', {'sec', 'acc_x', 'acc_y', 'acc_z', 'gyro_x', 'gyro_y', 'gyro_z', 'temp'});
+mpu6050TimeTable = table2timetable(T, 'RowTimes', mpu6050TimeIndex);
+parquetwrite('mpu6050.parquet', mpu6050TimeTable);
+
+% Export HMC5833L data as Parquet
+hmc5883lTimeIndex = startTime + seconds(compassBuffer(:, 1));
+hmc5883lCombined = [compassBuffer(:, 1), compassBuffer(:, 2:end)];
+T = array2table(hmc5883lCombined, 'VariableNames', {'sec', 'compass_x', 'compass_y', 'compass_z'});
+hmc5883lTimeTable = table2timetable(T, 'RowTimes', hmc5883lTimeIndex);
+parquetwrite('hmc5883l.parquet', hmc5883lTimeTable);

--- a/data/set-1/pan-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-1/pan-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5ebe4592c520ca58009a16d2c01b0c9e508b14e5ef689ced95d737598f0b038
+size 53029

--- a/data/set-1/pan-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-1/pan-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12a294ec47cc6f8a8e2934b3e64b535a4ef9bd9c8a596b7345982bb25730df53
+size 88323

--- a/data/set-1/pan-x-pointing-forward/mpu6050.parquet
+++ b/data/set-1/pan-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7746e7436acf91d74499e80582ce8dbf4fe282049392c3f101a8270488d39016
+size 121458

--- a/data/set-1/pan-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-1/pan-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da457700d804efb2d69a394cbc69f1e88d352bab3154abdfeca73856f3e7cb8
+size 110184

--- a/data/set-1/pan-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-1/pan-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2598b906bcd7079ec280bc297216e6a8584fc75d64f981d0001d4818a38ae4d4
+size 98408

--- a/data/set-1/pan-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-1/pan-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:313123d357a85ba15313839b2fa7f057f5d7a563d4677b7c73c3670f081604b4
+size 47168

--- a/data/set-1/pan-y-pointing-left/hmc5883l.parquet
+++ b/data/set-1/pan-y-pointing-left/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6566f9b3048c32f07722d60b6e59f85df1ece29a8129a73cb4a4a2d59371833
+size 44502

--- a/data/set-1/pan-y-pointing-left/hmc5883l_compass.csv
+++ b/data/set-1/pan-y-pointing-left/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d6dfeb6b7f11f7b9d2776796b780a0cd5950654aaccbe41e3269148b49ad39b
+size 73011

--- a/data/set-1/pan-y-pointing-left/mpu6050.parquet
+++ b/data/set-1/pan-y-pointing-left/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68614b7fc912c2cf19bd63871040479174edb08f01ac3bb9deeecc91e01c39be
+size 105971

--- a/data/set-1/pan-y-pointing-left/mpu6050_accelerometer.csv
+++ b/data/set-1/pan-y-pointing-left/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32885ed37d653ead0a57b72ba8e35dc04dd9e7752ca3fe558f3ee31be8c1b32e
+size 93007

--- a/data/set-1/pan-y-pointing-left/mpu6050_gyroscope.csv
+++ b/data/set-1/pan-y-pointing-left/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9395ac2229eda2859fe8d1b7a2a3b97ac9ac40f85521d4a6f24d1560e698399
+size 82187

--- a/data/set-1/pan-y-pointing-left/mpu6050_temperature.csv
+++ b/data/set-1/pan-y-pointing-left/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbc8230323006fa16404ff03b6b05984258658c1e9c19b93f9fbec0120b9f05f
+size 39286

--- a/data/set-1/pan-z-pointing-up/hmc5883l.parquet
+++ b/data/set-1/pan-z-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34736ef9385827e4db227d618cc6a1a86ff2185920d2f745fe5e756b9cf370e
+size 44966

--- a/data/set-1/pan-z-pointing-up/hmc5883l_compass.csv
+++ b/data/set-1/pan-z-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b54843d15ff001d3a3330bd2be17b98964d1e48c9c1f71f6bd5046cc32cb20d1
+size 70737

--- a/data/set-1/pan-z-pointing-up/mpu6050.parquet
+++ b/data/set-1/pan-z-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59e115a56275b88577562205321489493124af8f17c76ef9e42079caf069572b
+size 114506

--- a/data/set-1/pan-z-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-1/pan-z-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03adf077a80fdc7f16613f0b69961cfd2da8d4cd71735e12b657a4fc6c8bd0b6
+size 88778

--- a/data/set-1/pan-z-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-1/pan-z-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8a45df444968f93d1c9ec4a829a03ccc13f631c5699acfd5edcf6e5555cceb4
+size 79734

--- a/data/set-1/pan-z-pointing-up/mpu6050_temperature.csv
+++ b/data/set-1/pan-z-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a1477108d62c072fb4ff993015bafe2a9986f57e46d8b2a973ff1bd8b42762a
+size 38085

--- a/data/set-1/rotate-360ccw-around-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-1/rotate-360ccw-around-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1b11ae9613526fdda461763573ffe08b4c5070278febfb2bff6c4c788f7c793
+size 33705

--- a/data/set-1/rotate-360ccw-around-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-1/rotate-360ccw-around-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbbab44399055d9455266f3546c5dcdf45d11e22c3ad1b95ff9ebaf347fb2ba
+size 39316

--- a/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050.parquet
+++ b/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbaab9260caf6036a007553a59f189a1287ee6200162b89873836d051e547e58
+size 75125

--- a/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13a081fede92d415cc1ade088d496365bf1f9b3fcfbaae87cab58ca214b56c2f
+size 51117

--- a/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b18e1a4f73758a3b61f5c94358e84fa3853a8674f5d5d97bb4706f47e5c5cd03
+size 45906

--- a/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-1/rotate-360ccw-around-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9173d01e23e5ed77f74d683ab2b8a23176241deb105350f5d25dcd51447ae4c9
+size 21733

--- a/data/set-1/rotate-360ccw-around-y-pointing-left/hmc5883l.parquet
+++ b/data/set-1/rotate-360ccw-around-y-pointing-left/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5f76b95c68b73ce3530f9ae636e287c12794ca4c302a3582849482af14ba1cf
+size 32840

--- a/data/set-1/rotate-360ccw-around-y-pointing-left/hmc5883l_compass.csv
+++ b/data/set-1/rotate-360ccw-around-y-pointing-left/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b54401affeaa8e1bea4c147ddc385f0d2dff0ffe531e57064bfeaa98d905677
+size 37781

--- a/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050.parquet
+++ b/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cab1b2682abee4c2814553093ba9ae4ff8d24e0d99c6f2c1030d6e4800163bd
+size 72883

--- a/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050_accelerometer.csv
+++ b/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7ffbf721972612f26327555b782fe1d383399234396e2718a55f12643f01653
+size 47588

--- a/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050_gyroscope.csv
+++ b/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efd3d45e7e620428e5220feb6c8f690b0bdc666fae1389b03a9386278a8b4c9f
+size 41942

--- a/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050_temperature.csv
+++ b/data/set-1/rotate-360ccw-around-y-pointing-left/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8fba44d22c6e13bebf21f15e7aaf66e9d29be22c9c7cd0e193f964eae5b4c0f
+size 20236

--- a/data/set-1/rotate-360ccw-around-z-pointing-up/hmc5883l.parquet
+++ b/data/set-1/rotate-360ccw-around-z-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59c68ad0f35b3dfe0eeee7c2c4bdc7f7924e788e25f49ec2bd7c23263b12468
+size 40864

--- a/data/set-1/rotate-360ccw-around-z-pointing-up/hmc5883l_compass.csv
+++ b/data/set-1/rotate-360ccw-around-z-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c69e2f35afbeaf2fdc4fa641a5fcae214b1c2be48246994a004e182b289023f
+size 59203

--- a/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050.parquet
+++ b/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed93a2e0faf1cefeb8ec8d98fdac2ac491814767c8e68202d289945e33c475d8
+size 95884

--- a/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f636b9eba1ff497ebd57d83c96051720b10cdd06bd080ca0b0d2efc5ab73be9e
+size 74499

--- a/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7b7b8e7a4c340060974e029b00b41c483de00c1ee32612d64d0b7debb7827f9
+size 65508

--- a/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050_temperature.csv
+++ b/data/set-1/rotate-360ccw-around-z-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f7cb444da719e8ac0a98040cbc29d943d7b6bc019b9f6ef08a75f210cc477dd
+size 31655

--- a/data/set-1/tilt-around-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-1/tilt-around-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f7f9939dfa2c41f125c5e911d354fd6da899476df422a1c86dadc16ff59e4c3
+size 90240

--- a/data/set-1/tilt-around-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-1/tilt-around-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de51cc1864db9d83743793126f05dac05ec541d5986d8eff240b0e1d263a2714
+size 120594

--- a/data/set-1/tilt-around-x-pointing-forward/mpu6050.parquet
+++ b/data/set-1/tilt-around-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f72879c4456a0c72d9eef8d63d481bd4b0b892755765a60320f34595c7a6e2e8
+size 204776

--- a/data/set-1/tilt-around-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-1/tilt-around-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:701a84565d9d325b9f87831d9c6f2036fcd8f5fa78cfdf9aff51b4c61cc72fe2
+size 159277

--- a/data/set-1/tilt-around-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-1/tilt-around-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caaa7ca9d10a1274645f7d3891cf6ce538857513f796b84d6593d52e9a6cca24
+size 142787

--- a/data/set-1/tilt-around-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-1/tilt-around-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6d69072e62c61119e9cebf04649ee6e1628697ad7896132df4a391b280d7eed
+size 66842

--- a/data/set-1/tilt-around-x-pointing-up/hmc5883l.parquet
+++ b/data/set-1/tilt-around-x-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d295997f316cd01ed2adfb36f4ad1b3fa5eb08cbd66ce2e83c9e4e63f0a3350
+size 67962

--- a/data/set-1/tilt-around-x-pointing-up/hmc5883l_compass.csv
+++ b/data/set-1/tilt-around-x-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8bd58b88360ab741f7c9e4dd4c11a005d50041cba94bbd7d2feea4c1c505c15
+size 99175

--- a/data/set-1/tilt-around-x-pointing-up/mpu6050.parquet
+++ b/data/set-1/tilt-around-x-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feb483688936d1b781a6161683ee00d45edcd1ed26f2659a5a72dd08ee706db6
+size 159428

--- a/data/set-1/tilt-around-x-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-1/tilt-around-x-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e73a39b9891a3ab5ad0afcdbd88ef26be81e4ed61deb676b504d152e3472a40b
+size 130437

--- a/data/set-1/tilt-around-x-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-1/tilt-around-x-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cdd7913335f16496813a72805b424f4dc1c65077393e93ad91281fd852fad39
+size 112990

--- a/data/set-1/tilt-around-x-pointing-up/mpu6050_temperature.csv
+++ b/data/set-1/tilt-around-x-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:608e5cde7b166964295fee420cc3e236bd1ae13c1bc301d7bea567d2502ac743
+size 53184

--- a/data/set-1/tilt-around-y-pointing-left/hmc5883l.parquet
+++ b/data/set-1/tilt-around-y-pointing-left/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17811ee088ae4d159bf61a2e7417815a2c48189fdabf0a9ddb237ee7cf165af4
+size 90967

--- a/data/set-1/tilt-around-y-pointing-left/hmc5883l_compass.csv
+++ b/data/set-1/tilt-around-y-pointing-left/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe911a24d8e9b65e8ed5d2c7c868f9f9dde28bcc129b28e0a9770e9d06a8f2b4
+size 127043

--- a/data/set-1/tilt-around-y-pointing-left/mpu6050.parquet
+++ b/data/set-1/tilt-around-y-pointing-left/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c989ff2fd02230177225f48ddc99136f4129755353461a0026f28259640fe48
+size 218970

--- a/data/set-1/tilt-around-y-pointing-left/mpu6050_accelerometer.csv
+++ b/data/set-1/tilt-around-y-pointing-left/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bded4d66c856da99cefc394c18f37b08948d554fb36a6960573d0bb1672cdd3a
+size 159433

--- a/data/set-1/tilt-around-y-pointing-left/mpu6050_gyroscope.csv
+++ b/data/set-1/tilt-around-y-pointing-left/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f7bfb3ae93d5e4bd627112fbeb8017a828ca1bb2e8e6edb0a268b726e2a58ab
+size 144420

--- a/data/set-1/tilt-around-y-pointing-left/mpu6050_temperature.csv
+++ b/data/set-1/tilt-around-y-pointing-left/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9b7c1bbf47e30c28366100c04593fa8b96d66d32fc641ee2a3fe4e0a5d08bbd
+size 66268

--- a/data/set-1/tilt-around-y-pointing-up/hmc5883l.parquet
+++ b/data/set-1/tilt-around-y-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f81875df11d656fef3a32466e884f72e0124b516a5c0e96b594cf126f6c87fff
+size 68527

--- a/data/set-1/tilt-around-y-pointing-up/hmc5883l_compass.csv
+++ b/data/set-1/tilt-around-y-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ddbe74b8eec035b1d275a45cc5362674ab470ef517f79a8b7db7cbd143e7b3b
+size 103766

--- a/data/set-1/tilt-around-y-pointing-up/mpu6050.parquet
+++ b/data/set-1/tilt-around-y-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc39955516a64be7e4b5da58149f6ea822b71fc54c7985e9584985f52b16d828
+size 161289

--- a/data/set-1/tilt-around-y-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-1/tilt-around-y-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbdedf200914ae481f138bc671b4500f2dc79a284253dc0d645f505aa7892164
+size 137267

--- a/data/set-1/tilt-around-y-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-1/tilt-around-y-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:016dacc235a6801ef544283925c88e24eeb8c6d8590c6438d55191bfa9a57e2b
+size 117676

--- a/data/set-1/tilt-around-y-pointing-up/mpu6050_temperature.csv
+++ b/data/set-1/tilt-around-y-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df14bee5a9e199414cb64702654edc46d5074a70f2095f5bd04d7aa49b12038f
+size 53918

--- a/data/set-1/tilt-around-z-pointing-up/hmc5883l.parquet
+++ b/data/set-1/tilt-around-z-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:184421c75b5d9315eca028eeb3fc56136e59afbdb2e423324b7c4b27eb5e6e6b
+size 73142

--- a/data/set-1/tilt-around-z-pointing-up/hmc5883l_compass.csv
+++ b/data/set-1/tilt-around-z-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66fdad6cd75cf9f938fb49a5e2ed190fa74df3224f611a67228437ae757386d7
+size 109783

--- a/data/set-1/tilt-around-z-pointing-up/mpu6050.parquet
+++ b/data/set-1/tilt-around-z-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06ec61e0f49f9b878edd171b239522332ca5ccf9fa99186e292ebc9e6c560d5f
+size 172519

--- a/data/set-1/tilt-around-z-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-1/tilt-around-z-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bfe2e938dfc199b3728e467eaca261ce631b60b2463e9855cf2a76a32a10f45
+size 137877

--- a/data/set-1/tilt-around-z-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-1/tilt-around-z-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d32f0090e0854770fba9d3bc9e7152865e5a0c57a7bfb6122d08a2010c1d63a9
+size 122924

--- a/data/set-1/tilt-around-z-pointing-up/mpu6050_temperature.csv
+++ b/data/set-1/tilt-around-z-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:996b587e8e23fe8716b2772bc8eafd29a41796d8fa15408c34269e93a91684c0
+size 56496

--- a/data/set-1/tilt-sphere/hmc5883l.parquet
+++ b/data/set-1/tilt-sphere/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53449e01380d54adaf8fd5da54d8335f9e26394e96f2654eb393847c22bd51f1
+size 107575

--- a/data/set-1/tilt-sphere/hmc5883l_compass.csv
+++ b/data/set-1/tilt-sphere/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f438f13b310ca3b0c4961f55198067671b91ce4da2f390e7f0790b6fdc2c5b16
+size 142170

--- a/data/set-1/tilt-sphere/mpu6050.parquet
+++ b/data/set-1/tilt-sphere/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f14594b7765ba37a04ae304d74e28b39e92af53b946008be28e15fd4f42fd7e
+size 263730

--- a/data/set-1/tilt-sphere/mpu6050_accelerometer.csv
+++ b/data/set-1/tilt-sphere/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a2bce22641b968f746e5ba0a6d59943efb07f557085122f3bae120956a9527c
+size 180283

--- a/data/set-1/tilt-sphere/mpu6050_gyroscope.csv
+++ b/data/set-1/tilt-sphere/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18df94ab3d46e2b6e62f9d0997a7fe78f0ec45096bc74ca2730ce230588bb868
+size 161230

--- a/data/set-1/tilt-sphere/mpu6050_temperature.csv
+++ b/data/set-1/tilt-sphere/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9082e3b5279caf1d9815e2c435cf50ee007cab4d87b8aaee63b12a7adf76bc72
+size 77113

--- a/data/set-1/unmoved-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-1/unmoved-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff48217007158a8025b4fb554e7cb6267007566ac90d6e91f7374510b6828846
+size 90560

--- a/data/set-1/unmoved-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-1/unmoved-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52d598802ad32ed0ab8eaaeda7b90e133109db4edb6b3aebbddd58e156a1cc30
+size 166298

--- a/data/set-1/unmoved-x-pointing-forward/mpu6050.parquet
+++ b/data/set-1/unmoved-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3e088eab41d5bb8d430cb6072667f1a8f64eae4ed93de57aa3afc9e13a721ca
+size 146215

--- a/data/set-1/unmoved-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-1/unmoved-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd68b5abe83e5f06f162d52da3ef4a7c0457628ae79eee3697ecc97147ff711
+size 207571

--- a/data/set-1/unmoved-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-1/unmoved-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae7eeb53964e7dba3b3d336dbb8abaf32ac112403a76391e8bc09db5ab3b8624
+size 186746

--- a/data/set-1/unmoved-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-1/unmoved-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77e64e2cdecb8c7dece81595711c224248c06e270dac4fcc66233d48d60b5b57
+size 88775

--- a/data/set-1/unmoved-x-pointing-up/hmc5883l.parquet
+++ b/data/set-1/unmoved-x-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5604eca1b37e4cdfa17e88ab5ede08f67d7300266d8a03591eca0fff3e2337c3
+size 98659

--- a/data/set-1/unmoved-x-pointing-up/hmc5883l_compass.csv
+++ b/data/set-1/unmoved-x-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68fdf22046a1b89434fc9bd9a679e1a02b1eb5fca07f8a12213f0a1598dcde0e
+size 170689

--- a/data/set-1/unmoved-x-pointing-up/mpu6050.parquet
+++ b/data/set-1/unmoved-x-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8e77bb84422b77adc0e4a4a846ed9f03b7dfee7c8ab8d11e2663f833c646f89
+size 162426

--- a/data/set-1/unmoved-x-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-1/unmoved-x-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c29d59209cce9f0f0cceca0d3a2c6fa4d3e82e2d3136a1a1e763a77f8b41afd
+size 241425

--- a/data/set-1/unmoved-x-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-1/unmoved-x-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83c46d09d01b16ada0188bb412b1143d14d04ba1e43697a91b0716a61530d5e5
+size 205747

--- a/data/set-1/unmoved-x-pointing-up/mpu6050_temperature.csv
+++ b/data/set-1/unmoved-x-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fecf04fc734817edfcbb458dcf6ca04aee40c13862798bfb7cd4b87c1428b96
+size 97574

--- a/data/set-1/unmoved-z-pointing-left/hmc5883l.parquet
+++ b/data/set-1/unmoved-z-pointing-left/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:023b6a783d1ffecb4dfea990fdf212ef86895d089fb468a45aa095947fd07fda
+size 89209

--- a/data/set-1/unmoved-z-pointing-left/hmc5883l_compass.csv
+++ b/data/set-1/unmoved-z-pointing-left/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:348b397d0bd4370bae625b8b9aed00b66b1c7be9165c1309a31e32f4d8b7489d
+size 153678

--- a/data/set-1/unmoved-z-pointing-left/mpu6050.parquet
+++ b/data/set-1/unmoved-z-pointing-left/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d33ec436641b4432b1eabea25451940afdc4b8d38fe70184b502e263918c22d2
+size 145842

--- a/data/set-1/unmoved-z-pointing-left/mpu6050_accelerometer.csv
+++ b/data/set-1/unmoved-z-pointing-left/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ecf6185060640d737bc25966daa76a2f6c78a7c0007a370047211355e5857f0
+size 203923

--- a/data/set-1/unmoved-z-pointing-left/mpu6050_gyroscope.csv
+++ b/data/set-1/unmoved-z-pointing-left/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29e0ae26822bb14c14de29e290b251c4a742c25e102d9dd0ab364b0866e2397c
+size 189773

--- a/data/set-1/unmoved-z-pointing-left/mpu6050_temperature.csv
+++ b/data/set-1/unmoved-z-pointing-left/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc1a6cbd558d41e8a012dce625d66754233c3b7c06667888cb85371823480bbe
+size 90191

--- a/data/set-2/full-sphere/hmc5883l.parquet
+++ b/data/set-2/full-sphere/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56535b9a2d7dac1ac9e75b089202876e772e311f5e04c0c1b63874aba278e6df
+size 187490

--- a/data/set-2/full-sphere/hmc5883l_compass.csv
+++ b/data/set-2/full-sphere/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ad44a6ec4234b6f382f29488c84318279c0b68e873298c38f576d1b146b5717
+size 267521

--- a/data/set-2/full-sphere/mpu6050.parquet
+++ b/data/set-2/full-sphere/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:052240c29c049039acfbccdded061786345c4f9e37f2247b4b7996f0aeeef6ff
+size 418533

--- a/data/set-2/full-sphere/mpu6050_accelerometer.csv
+++ b/data/set-2/full-sphere/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:969740a707a8d4f81bcf0907be76c61e8d00962119dd601e9a7836cfd07b7f04
+size 347613

--- a/data/set-2/full-sphere/mpu6050_gyroscope.csv
+++ b/data/set-2/full-sphere/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3413bc2418066e6009779641b65bdbb6adabeb1e0b1d65b28223baad0a14ab50
+size 303755

--- a/data/set-2/full-sphere/mpu6050_temperature.csv
+++ b/data/set-2/full-sphere/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d8f877cd073c963a36bc5fb40af659112d35b9eced54b5320b1f1fc3b3b9ba9
+size 146384

--- a/data/set-2/pan-along-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-2/pan-along-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dbb4f9af3d3b04a004eb2618df5e7aef6dc2046f0de0a1e52d1495b35adc9ae
+size 46119

--- a/data/set-2/pan-along-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-2/pan-along-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec69ea286862b3b3af88aa68f4d5813ad79e53141b6697a10e814ddcfece8b53
+size 71777

--- a/data/set-2/pan-along-x-pointing-forward/mpu6050.parquet
+++ b/data/set-2/pan-along-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cc25b23c00d10029624419056f0e876f6a788b6a3db5e9b406ef5995e727dd9
+size 103960

--- a/data/set-2/pan-along-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-2/pan-along-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc45dc47cfcd84c97fe65c7815da7de6cd415bd86510886109d923f6b2583cab
+size 95687

--- a/data/set-2/pan-along-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-2/pan-along-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e927e88d42e7b2cd09fad1347f82ced6fafa8cda17528713e84f0a648ea317c
+size 82157

--- a/data/set-2/pan-along-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-2/pan-along-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3738bb5bdccd034095fb675122eaa5dc81e7c0b01d2619f1b1ca9bc5169cd38f
+size 39411

--- a/data/set-2/pan-along-y-pointing-left/hmc5883l.parquet
+++ b/data/set-2/pan-along-y-pointing-left/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:625369e6633f5d0cb92c03da9d8ac9d4f5530608ff9e77fe5ca788aee54d9dac
+size 54568

--- a/data/set-2/pan-along-y-pointing-left/hmc5883l_compass.csv
+++ b/data/set-2/pan-along-y-pointing-left/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5542c372c52927b27cb815d764dd55cbf3056acd3ef86bf9fb959130e9aaeb9
+size 86196

--- a/data/set-2/pan-along-y-pointing-left/mpu6050.parquet
+++ b/data/set-2/pan-along-y-pointing-left/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbb27b6c35622d1ef0ec99fda9f72f39c77fc64b0d103691a9abfb9464469174
+size 119658

--- a/data/set-2/pan-along-y-pointing-left/mpu6050_accelerometer.csv
+++ b/data/set-2/pan-along-y-pointing-left/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94e94b479b921faec4dc0583246e83442427c3900d5c519e675dd93d6a46736c
+size 115945

--- a/data/set-2/pan-along-y-pointing-left/mpu6050_gyroscope.csv
+++ b/data/set-2/pan-along-y-pointing-left/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ba44985ee6b989b1d80f7cbd353395e21c1750f79cb44dba656bc5b38cd649e
+size 99703

--- a/data/set-2/pan-along-y-pointing-left/mpu6050_temperature.csv
+++ b/data/set-2/pan-along-y-pointing-left/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0c774ce08243b158230330a40551fe9b29f5df1223fe22fe11c27061988a7f0
+size 47696

--- a/data/set-2/pan-along-z-pointing-up/hmc5883l.parquet
+++ b/data/set-2/pan-along-z-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47fda6efd2f861258d4d8c3a5ea23055a4960636668bc60121ad6a6295cc1f98
+size 42393

--- a/data/set-2/pan-along-z-pointing-up/hmc5883l_compass.csv
+++ b/data/set-2/pan-along-z-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daa11c3c713afdd0904a099cc2040c84b39bb9a37c1925b7526824646b2b4f2e
+size 63829

--- a/data/set-2/pan-along-z-pointing-up/mpu6050.parquet
+++ b/data/set-2/pan-along-z-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b17f7c00d09fd4d758006aded70c3c28799da5d16b7054bf81006768d0b250a
+size 103180

--- a/data/set-2/pan-along-z-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-2/pan-along-z-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f4379fc26706d6ad35fb726eaf2bf23921c234703958c291507bac9761b758
+size 85340

--- a/data/set-2/pan-along-z-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-2/pan-along-z-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e90e399178a6280c77a89a583d700a98a3d71908084eca87d1ee32f03575f3f
+size 73818

--- a/data/set-2/pan-along-z-pointing-up/mpu6050_temperature.csv
+++ b/data/set-2/pan-along-z-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dde9c720fc71f848b8aea7e349ff2586d1dcdfd590d104be7631f698cdecac3a
+size 35235

--- a/data/set-2/roll-and-tilt-at-45-90/hmc5883l.parquet
+++ b/data/set-2/roll-and-tilt-at-45-90/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:505af402675bf685597ed6329eb422f5b02c8d84d6200bd91770bafbef92007c
+size 70054

--- a/data/set-2/roll-and-tilt-at-45-90/hmc5883l_compass.csv
+++ b/data/set-2/roll-and-tilt-at-45-90/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1adc063f9c5e7093e2610ba91bf8596d1b64e9b2147e6000b640acf161f672fc
+size 94177

--- a/data/set-2/roll-and-tilt-at-45-90/mpu6050.parquet
+++ b/data/set-2/roll-and-tilt-at-45-90/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:112a18e51ff398ceca343e6feb027b739dfe67ae305eeb9125570177e2b6ad32
+size 156696

--- a/data/set-2/roll-and-tilt-at-45-90/mpu6050_accelerometer.csv
+++ b/data/set-2/roll-and-tilt-at-45-90/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3c53ecbd42d69213553277df8d692c2cd49be8b0ad264da592861d9ecca20ce
+size 122436

--- a/data/set-2/roll-and-tilt-at-45-90/mpu6050_gyroscope.csv
+++ b/data/set-2/roll-and-tilt-at-45-90/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b1c30eb1936aab7341b5031d881b02e754466ff195ebe9a292f17d64b915cd8
+size 106041

--- a/data/set-2/roll-and-tilt-at-45-90/mpu6050_temperature.csv
+++ b/data/set-2/roll-and-tilt-at-45-90/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7abb179a81a437f92f7041b8af49e96f92797724a8b2bcbad5caefc1be1ac447
+size 50697

--- a/data/set-2/rotate-ccw-around-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-2/rotate-ccw-around-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b54740235df5b0ac536c84dc0b3871e4c02ab5f3bbf80bac5f0496eb2d06ec10
+size 47562

--- a/data/set-2/rotate-ccw-around-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aae417444bf5df12822ee308d86ae8fc37c6b0a976d5385a2588007eac4cac2d
+size 60020

--- a/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050.parquet
+++ b/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6712fa81047ac80f1e5468b2a78897b75eeae62c8af504c856e017d528248006
+size 106031

--- a/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d4ca5d1f58b8cf02bc6c805ebfcd359f533229b0f49d42c1cec63f6e6f87137
+size 80314

--- a/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:725d5fcd5a467c4e4f1e93e091a036d0e674d0b6a4e5c45e93c1c407c0e46c0f
+size 70701

--- a/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c8da57163f70bda390b96dac5978f712f768ac03b29706610c448c2c27b3404
+size 33421

--- a/data/set-2/rotate-ccw-around-x-pointing-up/hmc5883l.parquet
+++ b/data/set-2/rotate-ccw-around-x-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f95a14877b5541632e61b8c3ab6788c9f7166adc403ac988e26f3b8ad746cdb4
+size 37785

--- a/data/set-2/rotate-ccw-around-x-pointing-up/hmc5883l_compass.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4746906df7e582c154388dfdd403ab63322366fd856eccb52e6830cfdf4c270c
+size 53577

--- a/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050.parquet
+++ b/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8d5a30cc4e4435844aa5922598f2e27dfbf75473fb02020f799eb899d1965fd
+size 83731

--- a/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:187e1b821131f3a105578d670bbe7d9c9a85b561f42698d8b2a0470a78b74a4e
+size 70713

--- a/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:231e507a50f522bcb06b21707957ccd303a9e38c9523f085c1be5eabbb5555fc
+size 60973

--- a/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050_temperature.csv
+++ b/data/set-2/rotate-ccw-around-x-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cc374d2b6bcb3e28458f182562fd750e05be65203add647b511f0e75347d463
+size 28819

--- a/data/set-2/rotate-ccw-around-y-pointing-left/hmc5883l.parquet
+++ b/data/set-2/rotate-ccw-around-y-pointing-left/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33f0215bbc1e71a92ddb79efe9bbd96ab3d23289220349cf1ed4f116f4ec0894
+size 57510

--- a/data/set-2/rotate-ccw-around-y-pointing-left/hmc5883l_compass.csv
+++ b/data/set-2/rotate-ccw-around-y-pointing-left/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee909f0d5372dde41dad5ef6a946502a8d6605e2b0fb2fe600de46aa2da8445
+size 74157

--- a/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050.parquet
+++ b/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29301c7ef96e84e7ac17b19f9493d7b5c86ba317737c0d1b8cff7200d9da40df
+size 127527

--- a/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050_accelerometer.csv
+++ b/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bcc9bbc765ff13a569524bd177356ec05fe74bb5225d4001df6ebb9acb00d84
+size 97143

--- a/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050_gyroscope.csv
+++ b/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7643075ce4aebecc6434919bd9aa40f874abea59e579644ec8b578d461bfa78
+size 83241

--- a/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050_temperature.csv
+++ b/data/set-2/rotate-ccw-around-y-pointing-left/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00bf2ead0cf5bf4ecbc03803fdd832143969157a4ff103f03e3a901fc334a2b
+size 40401

--- a/data/set-2/rotate-ccw-around-z-pointing-up/hmc5883l.parquet
+++ b/data/set-2/rotate-ccw-around-z-pointing-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aea4b895c11a0dce7a0f1a64abc24659ad9cd1a8fb5fe4533c460cf301e78c1e
+size 43223

--- a/data/set-2/rotate-ccw-around-z-pointing-up/hmc5883l_compass.csv
+++ b/data/set-2/rotate-ccw-around-z-pointing-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:375ab151b66cdef708f1e01eb5d6a6cbbff2f310fcc0dd053c2df9457f630f85
+size 61898

--- a/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050.parquet
+++ b/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14a644db3f1cc649b63ba7b9010599c849ae85e694cb803b7b54895f34aeafef
+size 96981

--- a/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050_accelerometer.csv
+++ b/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b11648adb7ae78497667ea0560d838594cd3ea617346928eeda178fa6df7e850
+size 81291

--- a/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050_gyroscope.csv
+++ b/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f29710a6473954778135e8f05501fd3e7b7125b7e0dfe958f55a67a817b81ba
+size 69118

--- a/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050_temperature.csv
+++ b/data/set-2/rotate-ccw-around-z-pointing-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26ee87cd89cf283bc2e3c8b6d7b2e4c0edbfd4334464abf074e15c8961da58eb
+size 33346

--- a/data/set-2/unmoved-with-x-pointing-forward-10min/hmc5883l.parquet
+++ b/data/set-2/unmoved-with-x-pointing-forward-10min/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:117a24b524a6c1f8d7b5d68ec680ad5802fc106bb5521a6d0ce8dac35ab4254d
+size 950745

--- a/data/set-2/unmoved-with-x-pointing-forward-10min/hmc5883l_compass.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward-10min/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a860a8cf6e4d2bba6c02d390c0857b01f732726f1796fe17540e6611164ec78
+size 1625423

--- a/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050.parquet
+++ b/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec24273f2d178cea4705a98713996bb3470e3e06fed238027a7583e5b5e9e68f
+size 1505712

--- a/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050_accelerometer.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4ee3e0440a517f4c5219b5e14ddc5ba9b5b4cf373e2be0640b1e62ea427cdf5
+size 2116056

--- a/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050_gyroscope.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4386788edc05586ab39a96313a29f768ec80e296409a58369830d3fbf4b8c9ca
+size 1919118

--- a/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050_temperature.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward-10min/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:467f60b8f0de8eeeb9827024f16aaf4b437b1fe0b1aa61376b59fe4e0af806bd
+size 872075

--- a/data/set-2/unmoved-with-x-pointing-forward/hmc5883l.parquet
+++ b/data/set-2/unmoved-with-x-pointing-forward/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:774ab37bb316de6859dca0541ecbea108ccab92f572b6b44137c123c59d24098
+size 174485

--- a/data/set-2/unmoved-with-x-pointing-forward/hmc5883l_compass.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8949bc03a48d8f1eeaf418c115909e890b1bdeb1051b9893b5084b036ce330a8
+size 306162

--- a/data/set-2/unmoved-with-x-pointing-forward/mpu6050.parquet
+++ b/data/set-2/unmoved-with-x-pointing-forward/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ba6eb23c285a4d7b31b1b90207257c3de86793a370d1f1eb00f1078f119f0b4
+size 280401

--- a/data/set-2/unmoved-with-x-pointing-forward/mpu6050_accelerometer.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:740785abe7ced014102d26e46f9a6e8479a958e6232430ba3f6cd910168762ef
+size 441490

--- a/data/set-2/unmoved-with-x-pointing-forward/mpu6050_gyroscope.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00fd3b8b323847b3cbc15ccba84c055cfd37a2160592d9cde20a23923be6752
+size 361207

--- a/data/set-2/unmoved-with-x-pointing-forward/mpu6050_temperature.csv
+++ b/data/set-2/unmoved-with-x-pointing-forward/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16b9a6324631405e42b25bb205391442073e37e76dbeff63f71ce787970f11bf
+size 170070

--- a/data/set-2/unmoved-with-z-pointing-front-and-x-up/hmc5883l.parquet
+++ b/data/set-2/unmoved-with-z-pointing-front-and-x-up/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c064d14fbf79ab45d6c7388028fcf1023b929aa8283d1890dd09e0a66fff359e
+size 188848

--- a/data/set-2/unmoved-with-z-pointing-front-and-x-up/hmc5883l_compass.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-x-up/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cf7d081dae873134d718115a09fe75df01798c3fc392d1f4e1abe90f34980d8
+size 341535

--- a/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050.parquet
+++ b/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f61ab6880c388d82662c52972897e272a66968a46cb899356c0203a3b9fbbee1
+size 301397

--- a/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050_accelerometer.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe03c02c81bf69aba1c9a6ddcd43f612d6c0eb1ddf8a2c5a18dd369d3943d345
+size 460882

--- a/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050_gyroscope.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8e690443380db40ba87a6e49118836e3be19569e4922167e57a240a13fc2c6
+size 388047

--- a/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050_temperature.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-x-up/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc7cc9aa8d91c43d9cf6b7cf8edd9a3eb4d7e08a16c06f32afd18089830de2bb
+size 183190

--- a/data/set-2/unmoved-with-z-pointing-front-and-y-down/hmc5883l.parquet
+++ b/data/set-2/unmoved-with-z-pointing-front-and-y-down/hmc5883l.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b310d6cdd4477cd85e8428e5739613926dde57ec59c87d72ff760db112da2bf
+size 143169

--- a/data/set-2/unmoved-with-z-pointing-front-and-y-down/hmc5883l_compass.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-y-down/hmc5883l_compass.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49d2c8ee581a4de6b94b50b44ceeda3b1d914d112963ba49e4e830e58bc93f0c
+size 250026

--- a/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050.parquet
+++ b/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d148104e6b82f1cc31babf343cc41e5725ea1344c25deccf63f312e704a9f04f
+size 233755

--- a/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050_accelerometer.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050_accelerometer.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dabad93c71173ff4f27936278c6b244f7016d824294b0a80d439a26ac942551
+size 321126

--- a/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050_gyroscope.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050_gyroscope.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c32352803788e4fa0359cc801a637cd749559c54f7dddcc70f84d3a6d3015437
+size 299429

--- a/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050_temperature.csv
+++ b/data/set-2/unmoved-with-z-pointing-front-and-y-down/mpu6050_temperature.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bed86d903fe21a460c8f953e2de995f4911b4cdbe132d312dc1b6ec62ce83466
+size 141453

--- a/tea.yaml
+++ b/tea.yaml
@@ -1,0 +1,7 @@
+# https://tea.xyz/what-is-this-file
+---
+version: 1.0.0
+codeOwners:
+  - '0xfB0cb2c716Ceb7A207C18c540c8EfdDf71B64689'
+quorum: 1
+


### PR DESCRIPTION
To simplify usage of the datasets in other repositories, e.g. by using this repo as a submodule, the data files (`.mat`) were converted to CSV and Parquet.